### PR TITLE
chore: Update Schemathesis version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "robotframework>=7.2.2",
     "robotframework-datadriver>=1.11.2",
     "robotframework-pythonlibcore>=4.4.1",
-    "schemathesis>=3.39.16",
+    "schemathesis>=4.0.0-beta.1",
 ]
 
 [dependency-groups]

--- a/utest/test_spec.py
+++ b/utest/test_spec.py
@@ -5,7 +5,8 @@ import schemathesis
 root = Path(__file__).parent.parent
 api_spec = root / "test_app" / "openapi.json"
 
-schema = schemathesis.from_path(api_spec, base_url="http://localhost:8000")
+schema = schemathesis.openapi.from_path(api_spec)
+schema.config.update(base_url="http://localhost:8000")
 
 
 @schema.parametrize()


### PR DESCRIPTION
Hey @aaltat 

These are my quick experiments on how the integration could look with Schemathesis v4, along with a couple of ideas for next steps:

- Extending `Options` with more config options that could be directly passed to `schema.config.update` and other sub-configs
- Generating positive / negative tests by passing `GenerationMode` to `as_strategy`
- I am not sure about the naming for test cases, as Schemathesis usually generates a lot of examples, and, for example, `path_parameters` may contain unprintable characters, or characters that will likely break the terminal.

Even though I don't have experience with Robot, I'll try to educate myself about best practices and workflows (and I'll be grateful if you could share some tips), so I can be more helpful here.

I think about this PR as a starting point for discussion